### PR TITLE
fix WebDAV: stream_get_contents() expects parameter 2 to be long, str…

### DIFF
--- a/sabre/http/lib/Message.php
+++ b/sabre/http/lib/Message.php
@@ -73,7 +73,8 @@ abstract class Message implements MessageInterface {
         }
         if (is_null($body)) {
             return '';
-        }
+	}
+
         $contentLength = $this->getHeader('Content-Length');
         if (!is_int($contentLength)) {
             return stream_get_contents($body);

--- a/sabre/http/lib/Message.php
+++ b/sabre/http/lib/Message.php
@@ -74,7 +74,6 @@ abstract class Message implements MessageInterface {
         if (is_null($body)) {
             return '';
 	}
-
         $contentLength = $this->getHeader('Content-Length');
         if (!is_int($contentLength)) {
             return stream_get_contents($body);

--- a/sabre/http/lib/Message.php
+++ b/sabre/http/lib/Message.php
@@ -75,7 +75,7 @@ abstract class Message implements MessageInterface {
             return '';
         }
         $contentLength = $this->getHeader('Content-Length');
-        if (null === $contentLength) {
+        if (!is_int($contentLength)) {
             return stream_get_contents($body);
         } else {
             return stream_get_contents($body, $contentLength);


### PR DESCRIPTION
fix for

**WebDAV: stream_get_contents() expects parameter 2 to be long, string given #680**

 in nextcloud server.

I experienced the same issue with Synology CloudSync - Webdav module and fixed it this way.
I could not find out, what the actual "Content-Length" header was because I could not insert any log statements in that part of the code.


And somehow I don't manage to pass this Signed-Off thing :-)
Sorry I am rather new to github pull requests. I'd appreciate it, if someone could give me guidance, thanks, Philipp