### PR TITLE
Fix possible infinite loop in RRuleIterator.php

### DIFF
--- a/sabre/vobject/lib/Recur/RRuleIterator.php
+++ b/sabre/vobject/lib/Recur/RRuleIterator.php
@@ -556,7 +556,7 @@ class RRuleIterator implements Iterator {
                     foreach ($this->byWeekNo as $byWeekNo) {
                         foreach ($dayOffsets as $dayOffset) {
                             $date = clone $this->currentDate;
-                            $date->setISODate($currentYear, $byWeekNo, $dayOffset);
+                            $date = $date->setISODate($currentYear, $byWeekNo, $dayOffset);
 
                             if ($date > $this->currentDate) {
                                 $checkDates[] = $date;
@@ -592,11 +592,11 @@ class RRuleIterator implements Iterator {
                     // loop through all YearDay and Days to check all the combinations
                     foreach ($this->byYearDay as $byYearDay) {
                         $date = clone $this->currentDate;
-                        $date->setDate($currentYear, 1, 1);
+                        $date = $date->setDate($currentYear, 1, 1);
                         if ($byYearDay > 0) {
-                            $date->add(new \DateInterval('P' . $byYearDay . 'D'));
+                            $date = $date->add(new \DateInterval('P' . $byYearDay . 'D'));
                         } else {
-                            $date->sub(new \DateInterval('P' . abs($byYearDay) . 'D'));
+                            $date = $date->sub(new \DateInterval('P' . abs($byYearDay) . 'D'));
                         }
 
                         if ($date > $this->currentDate && in_array($date->format('N'), $dayOffsets)) {


### PR DESCRIPTION
When the RRule FREQ is YEARLY and it uses BYYEARDAY only, an infinite loop could occur.
$this->currentDate may be an DateTimeImmutable, so a reassignment is necessary.

A similar issue in BYWEEKDAY has also been resolved.

This commit is similar to sabre-io/vobject@dd7a752a. See also sabre-io/vobject#383