### PR TITLE
Fixed VCard V3 with BASE64 encoding being rejected

### DIFF
--- a/sabre/vobject/lib/Property.php
+++ b/sabre/vobject/lib/Property.php
@@ -617,7 +617,7 @@ abstract class Property extends Node {
                         $allowedEncoding = ['QUOTED-PRINTABLE', 'BASE64', '8BIT'];
                         break;
                     case Document::VCARD30 :
-                        $allowedEncoding = ['B'];
+                        $allowedEncoding = ['B', 'BASE64'];
                         break;
 
                 }


### PR DESCRIPTION
Fixes issue https://github.com/nextcloud/server/issues/3366 where some early implementations of VCard 3.0 use the BASE64 (instead of B) encoding.