### PR TITLE
[sabre/vobject] Fix warnings on php7.3

### DIFF
--- a/patches.txt
+++ b/patches.txt
@@ -5,6 +5,7 @@ Patches:
 - SabreDAV: Make sure that files that are children of directories, are reported as files https://github.com/fruux/sabre-dav/issues/982
 - SabreDAV: Don't open the file on HEAD requests https://github.com/sabre-io/dav/pull/1058
 - SabreDAV: Properly parse carddav address-data https://github.com/sabre-io/dav/pull/1025
+- SabreVObject: Fix warnings on PHP 7.3 https://github.com/sabre-io/vobject/pull/424
 - SabreXML: Fix invalid PHP docs https://github.com/fruux/sabre-xml/pull/128
 - SabreXML: Prevent infinite loops for empty props element https://github.com/fruux/sabre-xml/pull/132
 - ZipStreamer: Fix zip generation for 7zip https://github.com/McNetic/PHPZipStreamer/pull/39

--- a/sabre/vobject/lib/Component/VCard.php
+++ b/sabre/vobject/lib/Component/VCard.php
@@ -511,7 +511,7 @@ class VCard extends VObject\Document {
                 switch ($property->name) {
 
                     case 'VERSION':
-                        continue;
+                        break;
 
                     case 'XML':
                         $value = $property->getParts();

--- a/sabre/vobject/lib/FreeBusyGenerator.php
+++ b/sabre/vobject/lib/FreeBusyGenerator.php
@@ -430,7 +430,7 @@ class FreeBusyGenerator {
                                 // instance. We are skipping this event from the output
                                 // entirely.
                                 unset($this->objects[$key]);
-                                continue;
+                                break;
                             }
 
                             if ($this->start) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3902676/49761014-21777080-fcc6-11e8-8f1f-1872362094c7.png)

e.g. https://drone.nextcloud.com/nextcloud/server/13493/135

fixed by https://github.com/sabre-io/vobject/pull/424 but unreleased.