### PR TITLE
Broker: add timezone to CANCEL messages

### DIFF
--- a/patches.txt
+++ b/patches.txt
@@ -6,6 +6,7 @@ Patches:
 - SabreDAV: Make sure that files that are children of directories, are reported as files https://github.com/fruux/sabre-dav/issues/982
 - SabreDAV: Don't open the file on HEAD requests https://github.com/sabre-io/dav/pull/1058
 - SabreDAV: Properly parse carddav address-data https://github.com/sabre-io/dav/pull/1025
+- SabreVObject: Broker: add timezone to CANCEL messages https://github.com/sabre-io/vobject/pull/412
 - SabreXML: Fix invalid PHP docs https://github.com/fruux/sabre-xml/pull/128
 - SabreXML: Prevent infinite loops for empty props element https://github.com/fruux/sabre-xml/pull/132
 - ZipStreamer: Fix zip generation for 7zip https://github.com/McNetic/PHPZipStreamer/pull/39

--- a/sabre/vobject/lib/ITip/Broker.php
+++ b/sabre/vobject/lib/ITip/Broker.php
@@ -523,6 +523,11 @@ class Broker {
                 // Creating the new iCalendar body.
                 $icalMsg = new VCalendar();
                 $icalMsg->METHOD = $message->method;
+
+                foreach ($calendar->select('VTIMEZONE') as $timezone) {
+                    $icalMsg->add(clone $timezone);
+                }
+
                 $event = $icalMsg->add('VEVENT', [
                     'UID'      => $message->uid,
                     'SEQUENCE' => $message->sequence,


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/12946 

If DTSTART and/or DTEND and other times are specified with a TZID, some clients
may fail reading the generated iCal data, since the VTIMEZONE definition is
missing.

I dont use Outlook but code make sense :see_no_evil: Backport these changes to `stable15`?