### PR TITLE
Remove status on REPORT

### DIFF
--- a/sabre/dav/lib/DAV/Xml/Element/Response.php
+++ b/sabre/dav/lib/DAV/Xml/Element/Response.php
@@ -118,10 +118,6 @@ class Response implements Element {
      * @return void
      */
     function xmlSerialize(Writer $writer) {
-
-        if ($status = $this->getHTTPStatus()) {
-            $writer->writeElement('{DAV:}status', 'HTTP/1.1 ' . $status . ' ' . \Sabre\HTTP\Response::$statusCodes[$status]);
-        }
         $writer->writeElement('{DAV:}href', $writer->contextUri . \Sabre\HTTP\encodePath($this->getHref()));
 
         $empty = true;


### PR DESCRIPTION
Solves: https://github.com/nextcloud/server/issues/15029

It seems that status is not allowed on top level, but only in prop/allprop.

Before:
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:status>HTTP/1.1 200 OK</d:status>
        <d:href>/nc/remote.php/dav/files/test/testFolder</d:href>
        <d:propstat>
            <d:prop>
                <oc:owner-id>test</oc:owner-id>
                <d:getetag>&quot;5cad995a5281a&quot;</d:getetag>
                <oc:permissions>RGDNVCK</oc:permissions>
                <d:getlastmodified>Wed, 10 Apr 2019 07:20:58 GMT</d:getlastmodified>
                <oc:id>00080126ocjycgrudn78</oc:id>
                <oc:favorite>1</oc:favorite>
                <nc:mount-type></nc:mount-type>
                <nc:note></nc:note>
                <nc:has-preview>false</nc:has-preview>
                <oc:size>0</oc:size>
                <nc:is-encrypted>0</nc:is-encrypted>
                <oc:owner-display-name>test</oc:owner-display-name>
                <oc:comments-unread>0</oc:comments-unread>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
        <d:propstat>
            <d:prop>
                <d:creationdate/>
                <d:getcontentlength/>
                <d:getcontenttype/>
            </d:prop>
            <d:status>HTTP/1.1 404 Not Found</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

After:
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:href>/nc/remote.php/dav/files/test/testFolder</d:href>
        <d:propstat>
            <d:prop>
                <oc:owner-id>test</oc:owner-id>
                <d:getetag>&quot;5cad995a5281a&quot;</d:getetag>
                <oc:permissions>RGDNVCK</oc:permissions>
                <d:getlastmodified>Wed, 10 Apr 2019 07:20:58 GMT</d:getlastmodified>
                <oc:id>00080126ocjycgrudn78</oc:id>
                <oc:favorite>1</oc:favorite>
                <nc:mount-type></nc:mount-type>
                <nc:note></nc:note>
                <nc:has-preview>false</nc:has-preview>
                <oc:size>0</oc:size>
                <nc:is-encrypted>0</nc:is-encrypted>
                <oc:owner-display-name>test</oc:owner-display-name>
                <oc:comments-unread>0</oc:comments-unread>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
        <d:propstat>
            <d:prop>
                <d:creationdate/>
                <d:getcontentlength/>
                <d:getcontenttype/>
            </d:prop>
            <d:status>HTTP/1.1 404 Not Found</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

As you can see we still have `<d:status>…</d:status>`, but only with in propstat.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>