### PR TITLE
Add mikey179/vfsstream to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,5 @@ rackspace/php-opencloud/samples
 mtdowling/jmespath.php/tests
 
 scssphp/scssphp/example
+
+mikey179/vfsstream


### PR DESCRIPTION
This dependency is only required for some tests. Patch make sure that git ~log~ status is not spammed with untracked files.

Need for this test: https://github.com/nextcloud/server/blob/8473a094991dcb8b8a495f65e814edde9a983f08/tests/lib/Files/Type/DetectionTest.php#L135-L137