### PR TITLE
Try workflow without composer update

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   php:
     runs-on: ubuntu-latest
-  
+
     name: Check vendor changes
     steps:
     - name: Checkout
@@ -20,8 +20,8 @@ jobs:
       with:
         php-version: 7.4
         coverage: none
-    - name: Update composer
-      run: composer self-update && composer --version
+    - name: Print composer version
+      run: composer --version
     - name: Install dependencies
       run: composer install --no-dev
     - name: Remove ignored files


### PR DESCRIPTION
PRs fail with

> Updating to version 1.9.3 (stable channel).
>    Downloading (connecting...)Downloading (100%)         
> 
>                                                                                                       
>   [ErrorException]                                                                                    
>   rename(/home/runner/.composer/cache/composer-temp.phar,/usr/local/bin/composer): Permission denied  
>                                                                                                       
> 
> self-update [-r|--rollback] [--clean-backups] [--no-progress] [--update-keys] [--stable] [--preview] [--snapshot] [--set-channel-only] [--] [<version>]

so let's see if we can do without the update.