### PR TITLE
leafo/scssphp: fix php7.4 error about value of type null

### DIFF
--- a/leafo/scssphp/src/Compiler.php
+++ b/leafo/scssphp/src/Compiler.php
@@ -5211,10 +5211,10 @@ class Compiler
         return new Node\Number(strlen($stringContent), '');
     }
 
-    protected static $libStrSlice = ['string', 'start-at', 'end-at'];
+    protected static $libStrSlice = ['string', 'start-at', 'end-at:-1'];
     protected function libStrSlice($args)
     {
-        if (isset($args[2]) && $args[2][1] == 0) {
+        if (isset($args[2]) && ! $args[2][1]) {
             return static::$nullString;
         }
 
@@ -5227,7 +5227,7 @@ class Compiler
             $start--;
         }
 
-        $end    = (int) $args[2][1];
+        $end    = isset($args[2]) ? (int) $args[2][1] : -1;
         $length = $end < 0 ? $end + 1 : ($end > 0 ? $end - $start : $end);
 
         $string[2] = $length


### PR DESCRIPTION
php7.4 issues the following error messages:
    Error PHP Trying to access array offset on value of type null at /var/www/nextcloud/3rdparty/leafo/scssphp/src/Compiler.php#5230

Backport the upstream patch https://github.com/scssphp/scssphp/commit/05a5d11ea7f68c52fdb6a5ca35cf46613b608445 to stable v18.