### PR TITLE
[stable19] Doctrine: Fix unquoted stmt fragments backslash escaping

### DIFF
--- a/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -28,9 +28,9 @@ class SQLParserUtils
     public const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    public const ESCAPED_SINGLE_QUOTED_TEXT   = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
-    public const ESCAPED_DOUBLE_QUOTED_TEXT   = '(?:"(?:\\\\\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
-    public const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
+    public const ESCAPED_SINGLE_QUOTED_TEXT   = "(?:'(?:\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
+    public const ESCAPED_DOUBLE_QUOTED_TEXT   = '(?:"(?:\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
+    public const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
     private const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\b(?i:ARRAY))\[(?:[^\]])*\]';
 
     /**

--- a/patches.txt
+++ b/patches.txt
@@ -2,6 +2,7 @@ Patches:
 
 - patchwork/utf8: Remove trigger_error() that spammed the error log
 - Doctrine: fix named parameter detection on sqlite with like queries https://github.com/doctrine/dbal/pull/3104
+- Doctrine: Fix unquoted stmt fragments backslash escaping https://github.com/doctrine/dbal/pull/3772
 - SabreDAV: Make sure that files that are children of directories, are reported as files https://github.com/fruux/sabre-dav/issues/982
 - SabreDAV: Don't open the file on HEAD requests https://github.com/sabre-io/dav/pull/1058
 - SabreDAV: Properly parse carddav address-data https://github.com/sabre-io/dav/pull/1025


### PR DESCRIPTION
Needed for https://github.com/nextcloud/server/pull/22118 - working on master because there doctrine/dbal:2.10.2 is used


