### PR TITLE
Update sabre/xml to fix XML parsing errors (with empty strings)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1104,6 +1104,7 @@
             "keywords": [
                 "reflection"
             ],
+            "abandoned": "roave/better-reflection",
             "time": "2018-06-14T14:45:07+00:00"
         },
         {
@@ -3902,16 +3903,16 @@
         },
         {
             "name": "sabre/xml",
-            "version": "2.2.0",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/xml.git",
-                "reference": "705f5cbf7f4fb1e3dd47173e3f026892818c8d46"
+                "reference": "c3b959f821c19b36952ec4a595edd695c216bfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/705f5cbf7f4fb1e3dd47173e3f026892818c8d46",
-                "reference": "705f5cbf7f4fb1e3dd47173e3f026892818c8d46",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/c3b959f821c19b36952ec4a595edd695c216bfc6",
+                "reference": "c3b959f821c19b36952ec4a595edd695c216bfc6",
                 "shasum": ""
             },
             "require": {
@@ -3919,12 +3920,13 @@
                 "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
                 "lib-libxml": ">=2.6.20",
-                "php": "^7.1",
+                "php": "^7.1 || ^8.0",
                 "sabre/uri": ">=1.0,<3.0.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2.16.1",
-                "phpunit/phpunit": "^7 || ^8"
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
             },
             "type": "library",
             "autoload": {
@@ -3961,7 +3963,7 @@
                 "dom",
                 "xml"
             ],
-            "time": "2020-01-31T18:52:58+00:00"
+            "time": "2020-10-03T10:08:14+00:00"
         },
         {
             "name": "scssphp/scssphp",

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -1129,7 +1129,8 @@
         "homepage": "https://www.doctrine-project.org/projects/reflection.html",
         "keywords": [
             "reflection"
-        ]
+        ],
+        "abandoned": "roave/better-reflection"
     },
     {
         "name": "egulias/email-validator",
@@ -4023,17 +4024,17 @@
     },
     {
         "name": "sabre/xml",
-        "version": "2.2.0",
-        "version_normalized": "2.2.0.0",
+        "version": "2.2.3",
+        "version_normalized": "2.2.3.0",
         "source": {
             "type": "git",
             "url": "https://github.com/sabre-io/xml.git",
-            "reference": "705f5cbf7f4fb1e3dd47173e3f026892818c8d46"
+            "reference": "c3b959f821c19b36952ec4a595edd695c216bfc6"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/sabre-io/xml/zipball/705f5cbf7f4fb1e3dd47173e3f026892818c8d46",
-            "reference": "705f5cbf7f4fb1e3dd47173e3f026892818c8d46",
+            "url": "https://api.github.com/repos/sabre-io/xml/zipball/c3b959f821c19b36952ec4a595edd695c216bfc6",
+            "reference": "c3b959f821c19b36952ec4a595edd695c216bfc6",
             "shasum": ""
         },
         "require": {
@@ -4041,14 +4042,15 @@
             "ext-xmlreader": "*",
             "ext-xmlwriter": "*",
             "lib-libxml": ">=2.6.20",
-            "php": "^7.1",
+            "php": "^7.1 || ^8.0",
             "sabre/uri": ">=1.0,<3.0.0"
         },
         "require-dev": {
             "friendsofphp/php-cs-fixer": "~2.16.1",
-            "phpunit/phpunit": "^7 || ^8"
+            "phpstan/phpstan": "^0.12",
+            "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
         },
-        "time": "2020-01-31T18:52:58+00:00",
+        "time": "2020-10-03T10:08:14+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {

--- a/sabre/xml/.gitignore
+++ b/sabre/xml/.gitignore
@@ -5,18 +5,4 @@ composer.lock
 # Tests
 tests/cov
 tests/.phpunit.result.cache
-.*.swp
-
-# Composer binaries
-bin/phpunit
-bin/php-cs-fixer
-bin/phpstan
-bin/phpstan.phar
-
-# Vim
-.*.swp
-
-# IDEs
-/.idea
-
 .php_cs.cache

--- a/sabre/xml/CHANGELOG.md
+++ b/sabre/xml/CHANGELOG.md
@@ -1,6 +1,20 @@
 ChangeLog
 =========
 
+2.2.3 (2020-10-03)
+------------------
+* #191: add changelog and version bump that was missed in 2.2.2
+
+2.2.2 (2020-10-03)
+------------------
+* #190: adjust libxml_disable_entity_loader calls ready for PHP 8.0 (@phil-davis)
+
+2.2.1 (2020-05-11)
+------------------
+
+* #183: fixed warning 'xml cannot be empty while reading', which might lead to a infinite-loop (@mrow4a)
+* #179, #178, #177 #176: several build/continous integration related improvements (@phil-davis)
+
 2.2.0 (2020-01-31)
 ------------------
 

--- a/sabre/xml/composer.json
+++ b/sabre/xml/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://sabre.io/xml/",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php" : "^7.1",
+        "php" : "^7.1 || ^8.0",
         "ext-xmlwriter" : "*",
         "ext-xmlreader" : "*",
         "ext-dom" : "*",
@@ -45,9 +45,23 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.16.1",
-        "phpunit/phpunit" : "^7 || ^8"
+        "phpstan/phpstan": "^0.12",
+        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },
-    "config" : {
-        "bin-dir" : "bin/"
+    "scripts": {
+        "phpstan": [
+            "phpstan analyse lib tests"
+        ],
+        "cs-fixer": [
+            "php-cs-fixer fix"
+        ],
+        "phpunit": [
+            "phpunit --configuration tests/phpunit.xml"
+        ],
+        "test": [
+            "composer phpstan",
+            "composer cs-fixer",
+            "composer phpunit"
+        ]
     }
 }

--- a/sabre/xml/lib/Reader.php
+++ b/sabre/xml/lib/Reader.php
@@ -55,7 +55,11 @@ class Reader extends XMLReader
      */
     public function parse(): array
     {
-        $previousEntityState = libxml_disable_entity_loader(true);
+        $previousEntityState = null;
+        $shouldCallLibxmlDisableEntityLoader = (\PHP_VERSION_ID < 80000);
+        if ($shouldCallLibxmlDisableEntityLoader) {
+            $previousEntityState = libxml_disable_entity_loader(true);
+        }
         $previousSetting = libxml_use_internal_errors(true);
 
         try {
@@ -78,7 +82,9 @@ class Reader extends XMLReader
             }
         } finally {
             libxml_use_internal_errors($previousSetting);
-            libxml_disable_entity_loader($previousEntityState);
+            if ($shouldCallLibxmlDisableEntityLoader) {
+                libxml_disable_entity_loader($previousEntityState);
+            }
         }
 
         return $result;

--- a/sabre/xml/lib/Service.php
+++ b/sabre/xml/lib/Service.php
@@ -115,12 +115,13 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
-
-            // If input is an empty string, then its safe to throw exception
-            if ('' === $input) {
-                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
-            }
         }
+
+        // If input is empty, then its safe to throw exception
+        if (empty($input)) {
+            throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+        }
+
         $r = $this->getReader();
         $r->contextUri = $contextUri;
         $r->XML($input, null, $this->options);
@@ -158,12 +159,13 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
-
-            // If input is empty string, then its safe to throw exception
-            if ('' === $input) {
-                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
-            }
         }
+
+        // If input is empty, then its safe to throw exception
+        if (empty($input)) {
+            throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+        }
+
         $r = $this->getReader();
         $r->contextUri = $contextUri;
         $r->XML($input, null, $this->options);

--- a/sabre/xml/lib/Version.php
+++ b/sabre/xml/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '2.2.0';
+    const VERSION = '2.2.3';
 }


### PR DESCRIPTION
https://github.com/sabre-io/xml/pull/166 had a regression that was fixed in https://github.com/sabre-io/xml/pull/183

Nextcloud 20 to 19 use v2.2.0. I'll update all stable branches once this has been approved.

For https://github.com/nextcloud/server/issues/22281