### PR TITLE
[stable19] Use composer v1 on CI

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -19,6 +19,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.4
+        tools: composer:v1
         coverage: none
     - name: Update composer
       run: sudo composer self-update && composer --version

--- a/composer/ClassLoader.php
+++ b/composer/ClassLoader.php
@@ -60,7 +60,7 @@ class ClassLoader
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
-            return call_user_func_array('array_merge', $this->prefixesPsr0);
+            return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
         }
 
         return array();


### PR DESCRIPTION
https://github.com/nextcloud/3rdparty/pull/530 fails with weird composer diffs. Maybe we should use v1 for the old branches.