### PR TITLE
fix(id3parser):  fixes #607

### DIFF
--- a/christophwurst/id3parser/src/getID3/Tags/getid3_id3v2.php
+++ b/christophwurst/id3parser/src/getID3/Tags/getid3_id3v2.php
@@ -1382,7 +1382,7 @@ class getid3_id3v2 extends getid3_handler
 				$parsedFrame['image_mime'] = '';
 				$imageinfo = array();
 				$imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo);
-				if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
+				if (is_array($imagechunkcheck) && ($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
 					$parsedFrame['image_mime']       = 'image/'.getid3_lib::ImageTypesLookup($imagechunkcheck[2]);
 					if ($imagechunkcheck[0]) {
 						$parsedFrame['image_width']  = $imagechunkcheck[0];


### PR DESCRIPTION
"should" fix:

```
Exception":"Error","Message":"Trying to access array offset on value of type bool at /var/www/nextcloud/3rdparty/christophwurst/id3parser/src/getID3/Tags/getid3_id3v2.php#1385
```

as reported in #607