### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -26,4 +26,4 @@ jobs:
       run: composer run vendor
     - name: Check vendor changes
       run: |
-        bash -c "[[ ! \"`git status --porcelain `\" ]] || ( echo 'Uncommited vendor changes' && git status && git diff && exit 1 )"
+        bash -c "[[ ! \"`git status --porcelain . :!composer/installed.json :!composer/installed.php :!composer/package-versions-deprecated/src/PackageVersions/Versions.php `\" ]] || ( echo 'Uncommited vendor changes' && git status && git diff && exit 1 )"


### PR DESCRIPTION
Don't check anymore paths that contains the information about the
previous commit instead of the current one when doing git status.

This should fix the CI

Signed-off-by: Carl Schwan <carl@carlschwan.eu>