### PR TITLE
Ignore Symfony 5 bumps for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,23 @@ updates:
     time: "03:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "symfony/console"
+      versions: ["5.x"]
+    - dependency-name: "symfony/event-dispatcher"
+      versions: [ "5.x" ]
+    - dependency-name: "symfony/event-dispatcher-contracts"
+      versions: [ "5.x" ]
+    - dependency-name: "symfony/polyfill-intl-grapheme"
+      versions: [ "5.x" ]
+    - dependency-name: "symfony/polyfill-intl-normalizer"
+      versions: ["5.x"]
+    - dependency-name: "symfony/process"
+      versions: [ "5.x" ]
+    - dependency-name: "symfony/routing"
+      versions: [ "5.x" ]
+    - dependency-name: "symfony/translation"
+      versions: [ "5.x" ]
 
 - package-ecosystem: composer
   directory: "/"


### PR DESCRIPTION
Dependabot shall send us 4.x updates instead.