### PR TITLE
Bump christophwurst/id3parser to 0.1.4

### DIFF
--- a/christophwurst/id3parser/src/getID3/Tags/getid3_id3v2.php
+++ b/christophwurst/id3parser/src/getID3/Tags/getid3_id3v2.php
@@ -1870,17 +1870,14 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = 0;
 			$parsedFrame['peakamplitude'] = getid3_lib::BigEndian2Float(substr($parsedFrame['data'], $frame_offset, 4));
 			$frame_offset += 4;
-			$rg_track_adjustment = getid3_lib::Dec2Bin(substr($parsedFrame['data'], $frame_offset, 2));
-			$frame_offset += 2;
-			$rg_album_adjustment = getid3_lib::Dec2Bin(substr($parsedFrame['data'], $frame_offset, 2));
-			$parsedFrame['raw']['track']['name']       = getid3_lib::Bin2Dec(substr($rg_track_adjustment, 0, 3));
-			$parsedFrame['raw']['track']['originator'] = getid3_lib::Bin2Dec(substr($rg_track_adjustment, 3, 3));
-			$parsedFrame['raw']['track']['signbit']    = getid3_lib::Bin2Dec(substr($rg_track_adjustment, 6, 1));
-			$parsedFrame['raw']['track']['adjustment'] = getid3_lib::Bin2Dec(substr($rg_track_adjustment, 7, 9));
-			$parsedFrame['raw']['album']['name']       = getid3_lib::Bin2Dec(substr($rg_album_adjustment, 0, 3));
-			$parsedFrame['raw']['album']['originator'] = getid3_lib::Bin2Dec(substr($rg_album_adjustment, 3, 3));
-			$parsedFrame['raw']['album']['signbit']    = getid3_lib::Bin2Dec(substr($rg_album_adjustment, 6, 1));
-			$parsedFrame['raw']['album']['adjustment'] = getid3_lib::Bin2Dec(substr($rg_album_adjustment, 7, 9));
+			foreach (array('track','album') as $rgad_entry_type) {
+				$rg_adjustment_word = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 2));
+				$frame_offset += 2;
+				$parsedFrame['raw'][$rgad_entry_type]['name']       = ($rg_adjustment_word & 0xE000) >> 13;
+				$parsedFrame['raw'][$rgad_entry_type]['originator'] = ($rg_adjustment_word & 0x1C00) >> 10;
+				$parsedFrame['raw'][$rgad_entry_type]['signbit']    = ($rg_adjustment_word & 0x0200) >>  9;
+				$parsedFrame['raw'][$rgad_entry_type]['adjustment'] = ($rg_adjustment_word & 0x0100);
+			}
 			$parsedFrame['track']['name']       = getid3_lib::RGADnameLookup($parsedFrame['raw']['track']['name']);
 			$parsedFrame['track']['originator'] = getid3_lib::RGADoriginatorLookup($parsedFrame['raw']['track']['originator']);
 			$parsedFrame['track']['adjustment'] = getid3_lib::RGADadjustmentLookup($parsedFrame['raw']['track']['adjustment'], $parsedFrame['raw']['track']['signbit']);

--- a/christophwurst/id3parser/src/getID3/getid3_lib.php
+++ b/christophwurst/id3parser/src/getID3/getid3_lib.php
@@ -295,14 +295,20 @@ class getid3_lib
 
 
 	public static function Dec2Bin($number) {
+		if (!is_numeric($number)) {
+			// https://github.com/JamesHeinrich/getID3/issues/299
+			trigger_error('TypeError: Dec2Bin(): Argument #1 ($number) must be numeric, '.gettype($number).' given', E_USER_WARNING);
+			return '';
+		}
+		$bytes = array();
 		while ($number >= 256) {
-			$bytes[] = (($number / 256) - (floor($number / 256))) * 256;
+			$bytes[] = (int) (($number / 256) - (floor($number / 256))) * 256;
 			$number = floor($number / 256);
 		}
-		$bytes[] = $number;
+		$bytes[] = (int) $number;
 		$binstring = '';
-		for ($i = 0; $i < count($bytes); $i++) {
-			$binstring = (($i == count($bytes) - 1) ? decbin($bytes[$i]) : str_pad(decbin($bytes[$i]), 8, '0', STR_PAD_LEFT)).$binstring;
+		foreach ($bytes as $i => $byte) {
+			$binstring = (($i == count($bytes) - 1) ? decbin($byte) : str_pad(decbin($byte), 8, '0', STR_PAD_LEFT)).$binstring;
 		}
 		return $binstring;
 	}
@@ -1147,7 +1153,7 @@ class getid3_lib
 	* @param string $suffix If the name component ends in suffix this will also be cut off.
 	* @return string
 	*/
-	public static function mb_basename($path, $suffix = null) {
+	public static function mb_basename($path, $suffix = '') {
 		$splited = preg_split('#/#', rtrim($path, '/ '));
 		return substr(basename('X'.$splited[count($splited) - 1], $suffix), 1);
 	}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"php": "^7.3|^8.0",
 		"aws/aws-sdk-php": "^3.35",
 		"bantu/ini-get-wrapper": "v1.0.1",
-		"christophwurst/id3parser": "^0.1.1",
+		"christophwurst/id3parser": "^0.1.4",
 		"cweagans/composer-patches": "^1.7",
 		"deepdiver/zipstreamer": "2.0.0",
 		"deepdiver1975/tarstreamer": "v2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b06c7bfbfdedee13eac020b7d24a21e",
+    "content-hash": "43d6e33525e295446eba2d97a5078674",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -251,16 +251,16 @@
         },
         {
             "name": "christophwurst/id3parser",
-            "version": "v0.1.2",
+            "version": "v0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/ID3Parser.git",
-                "reference": "d7f5e9e7db69a24e3111a2033cbdf640f9456f2f"
+                "reference": "050c9d81ea89b0cf53e23a27efc4e1840f9ab260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/ID3Parser/zipball/d7f5e9e7db69a24e3111a2033cbdf640f9456f2f",
-                "reference": "d7f5e9e7db69a24e3111a2033cbdf640f9456f2f",
+                "url": "https://api.github.com/repos/ChristophWurst/ID3Parser/zipball/050c9d81ea89b0cf53e23a27efc4e1840f9ab260",
+                "reference": "050c9d81ea89b0cf53e23a27efc4e1840f9ab260",
                 "shasum": ""
             },
             "require": {
@@ -285,9 +285,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ChristophWurst/ID3Parser/issues",
-                "source": "https://github.com/ChristophWurst/ID3Parser/tree/v0.1.2"
+                "source": "https://github.com/ChristophWurst/ID3Parser/tree/v0.1.4"
             },
-            "time": "2021-02-09T08:04:08+00:00"
+            "time": "2021-11-29T15:02:22+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -257,23 +257,23 @@
         },
         {
             "name": "christophwurst/id3parser",
-            "version": "v0.1.2",
-            "version_normalized": "0.1.2.0",
+            "version": "v0.1.4",
+            "version_normalized": "0.1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/ID3Parser.git",
-                "reference": "d7f5e9e7db69a24e3111a2033cbdf640f9456f2f"
+                "reference": "050c9d81ea89b0cf53e23a27efc4e1840f9ab260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/ID3Parser/zipball/d7f5e9e7db69a24e3111a2033cbdf640f9456f2f",
-                "reference": "d7f5e9e7db69a24e3111a2033cbdf640f9456f2f",
+                "url": "https://api.github.com/repos/ChristophWurst/ID3Parser/zipball/050c9d81ea89b0cf53e23a27efc4e1840f9ab260",
+                "reference": "050c9d81ea89b0cf53e23a27efc4e1840f9ab260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
-            "time": "2021-02-09T08:04:08+00:00",
+            "time": "2021-11-29T15:02:22+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -294,7 +294,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ChristophWurst/ID3Parser/issues",
-                "source": "https://github.com/ChristophWurst/ID3Parser/tree/v0.1.2"
+                "source": "https://github.com/ChristophWurst/ID3Parser/tree/v0.1.4"
             },
             "install-path": "../christophwurst/id3parser"
         },

--- a/composer/installed.php
+++ b/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
-        'reference' => '11d0523a07f09a005bace79d4172b734517f760d',
+        'reference' => 'a4ce933baff9c07e2bd9005cc101b791ea455682',
         'name' => 'nextcloud/3rdparty',
         'dev' => false,
     ),
@@ -47,12 +47,12 @@
             'dev_requirement' => false,
         ),
         'christophwurst/id3parser' => array(
-            'pretty_version' => 'v0.1.2',
-            'version' => '0.1.2.0',
+            'pretty_version' => 'v0.1.4',
+            'version' => '0.1.4.0',
             'type' => 'library',
             'install_path' => __DIR__ . '/../christophwurst/id3parser',
             'aliases' => array(),
-            'reference' => 'd7f5e9e7db69a24e3111a2033cbdf640f9456f2f',
+            'reference' => '050c9d81ea89b0cf53e23a27efc4e1840f9ab260',
             'dev_requirement' => false,
         ),
         'composer/package-versions-deprecated' => array(
@@ -286,7 +286,7 @@
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),
-            'reference' => '11d0523a07f09a005bace79d4172b734517f760d',
+            'reference' => 'a4ce933baff9c07e2bd9005cc101b791ea455682',
             'dev_requirement' => false,
         ),
         'nextcloud/lognormalizer' => array(

--- a/composer/package-versions-deprecated/src/PackageVersions/Versions.php
+++ b/composer/package-versions-deprecated/src/PackageVersions/Versions.php
@@ -37,7 +37,7 @@ final class Versions
   'bantu/ini-get-wrapper' => 'v1.0.1@4770c7feab370c62e23db4f31c112b7c6d90aee2',
   'beberlei/assert' => 'v3.3.1@5e721d7e937ca3ba2cdec1e1adf195f9e5188372',
   'brick/math' => '0.9.2@dff976c2f3487d42c1db75a3b180e2b9f0e72ce0',
-  'christophwurst/id3parser' => 'v0.1.2@d7f5e9e7db69a24e3111a2033cbdf640f9456f2f',
+  'christophwurst/id3parser' => 'v0.1.4@050c9d81ea89b0cf53e23a27efc4e1840f9ab260',
   'composer/package-versions-deprecated' => '1.11.99.4@b174585d1fe49ceed21928a945138948cb394600',
   'cweagans/composer-patches' => '1.7.1@9888dcc74993c030b75f3dd548bb5e20cdbd740c',
   'deepdiver/zipstreamer' => '2.0.0@b8c59647ff34fb97e8937aefb2a65de2bc4b4755',
@@ -120,7 +120,7 @@ final class Versions
   'web-auth/cose-lib' => 'v3.3.9@ed172d2dc1a6b87b5c644c07c118cd30c1b3819b',
   'web-auth/metadata-service' => 'v3.3.9@8488d3a832a38cc81c670fce05de1e515c6e64b1',
   'web-auth/webauthn-lib' => 'v3.3.9@04b98ee3d39cb79dad68a7c15c297c085bf66bfe',
-  'nextcloud/3rdparty' => 'dev-master@11d0523a07f09a005bace79d4172b734517f760d',
+  'nextcloud/3rdparty' => 'dev-master@a4ce933baff9c07e2bd9005cc101b791ea455682',
 );
 
     private function __construct()


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

Needed for PHP 8.1 compatibility

Replaces https://github.com/nextcloud/3rdparty/pull/935