### PR TITLE
Update GuzzleHttp\Psr7 function call

### DIFF
--- a/aws/aws-sdk-php/src/S3/S3Client.php
+++ b/aws/aws-sdk-php/src/S3/S3Client.php
@@ -754,7 +754,7 @@ class S3Client extends AwsClient implements S3ClientInterface
             . " parameters: Psr7 takes ownership of streams and will automatically close"
             . " streams when this method is called with a stream as the <code>Body</code>"
             . " parameter.  To prevent this, set the <code>Body</code> using"
-            . " <code>GuzzleHttp\Psr7\stream_for</code> method with a is an instance of"
+            . " <code>GuzzleHttp\Psr7\Utils::streamFor</code> method with a is an instance of"
             . " <code>Psr\Http\Message\StreamInterface</code>, and it will be returned"
             . " unmodified. This will allow you to keep the stream in scope. </p>";
         $docs['operations']['PutObject'] .=  $guzzleStreamMessage;

--- a/microsoft/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/microsoft/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -759,7 +759,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                 get_class(new Range(0))
             )
         );
-        $body = Psr7\stream_for($content);
+        $body = Psr7\Utils::streamFor($content);
 
         $method      = Resources::HTTP_PUT;
         $headers     = array();
@@ -1834,7 +1834,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreateBlockBlobOptions $options = null
     ) {
-        $body = Psr7\stream_for($content);
+        $body = Psr7\Utils::streamFor($content);
 
         //If the size of the stream is not seekable or larger than the single
         //upload threshold then call concurrent upload. Otherwise call putBlob.
@@ -1915,7 +1915,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreatePageBlobFromContentOptions $options = null
     ) {
-        $body = Psr7\stream_for($content);
+        $body = Psr7\Utils::streamFor($content);
         $self = $this;
 
         if (is_null($options)) {
@@ -2417,7 +2417,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreateBlobPagesOptions $options = null
     ) {
-        $contentStream = Psr7\stream_for($content);
+        $contentStream = Psr7\Utils::streamFor($content);
         //because the content is at most 4MB long, can retrieve all the data
         //here at once.
         $body = $contentStream->getContents();
@@ -2516,7 +2516,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $postParams     = array();
         $queryParams    = $this->createBlobBlockQueryParams($options, $blockId);
         $path           = $this->createPath($container, $blob);
-        $contentStream  = Psr7\stream_for($content);
+        $contentStream  = Psr7\Utils::streamFor($content);
         $body           = $contentStream->getContents();
 
         $options->setLocationMode(LocationMode::PRIMARY_ONLY);
@@ -2597,7 +2597,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $queryParams    = array();
         $path           = $this->createPath($container, $blob);
 
-        $contentStream  = Psr7\stream_for($content);
+        $contentStream  = Psr7\Utils::streamFor($content);
         $length         = $contentStream->getSize();
         $body           = $contentStream->getContents();
 


### PR DESCRIPTION
`stream_for()` is deprecated, replaced with `Utils::streamFor()`:
- https://github.com/nextcloud/3rdparty/blob/8a69e47/guzzlehttp/psr7/src/functions.php#L80
- https://github.com/guzzle/psr7#upgrading-from-function-api

Detected first here: https://github.com/nextcloud/server/pull/30210