### PR TITLE
Enable dependabot for stable24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,19 @@ updates:
 
 - package-ecosystem: composer
   directory: "/"
+  target-branch: stable24
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major"]
+
+- package-ecosystem: composer
+  directory: "/"
   target-branch: stable23
   schedule:
     interval: weekly


### PR DESCRIPTION
Added a task to https://github.com/nextcloud/server/wiki/Todos-before-a-release as well. 