### PR TITLE
Underscore in bucket name for GCS

### DIFF
--- a/aws/aws-sdk-php/src/S3/S3Client.php
+++ b/aws/aws-sdk-php/src/S3/S3Client.php
@@ -437,7 +437,7 @@ class S3Client extends AwsClient implements S3ClientInterface
         return ($bucketLen >= 3 && $bucketLen <= 63) &&
             // Cannot look like an IP address
             !filter_var($bucket, FILTER_VALIDATE_IP) &&
-            preg_match('/^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$/', $bucket);
+            preg_match('/^[a-z0-9]([a-z0-9\-\.\_]*[a-z0-9])?$/', $bucket);
     }
 
     public static function _apply_use_arn_region($value, array &$args, HandlerList $list)


### PR DESCRIPTION
Accept the underscore "_" character in the bucket name according to Google Cloud Storage documentation the "Bucket names can only contain lowercase letters, numeric characters, dashes (-), underscores (_), and dots (.)" https://cloud.google.com/storage/docs/buckets?authuser=5&hl=en#naming

Signed-off-by: Carlos Bermúdez <cahebebe@gmail.com>