### PR TITLE
Improvements at documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some 3rd party libraries that are necessary to run Nextcloud.
 ## Updating libraries manually
 
 1. Make sure to use the latest version of composer: `composer self-update`
-2. Edit composer.json and adjust the version of the library to the one to update to
+2. Edit composer.json and adjust the version of the library to the one to update to. Pay attention to use the full version number (i.e. ^5.3.14).
 3. Run `composer update thevendor/thelib` (replace accordingly)
 4. Delete all installed dependencies with `rm -rf ./*/`
 5. Run `composer install --no-dev`


### PR DESCRIPTION
Add a note to prevent future developers to specify a wrong version of a package. Is necessary to write the full version number.

Ref: https://github.com/nextcloud/3rdparty/pull/1304#discussion_r1094930891