### PR TITLE
fix(CI): Reduce dependabot update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,21 @@ updates:
   labels:
     - "dependencies"
     - "main"
+  ignore:
+    - dependency-name: "symfony/console"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/event-dispatcher"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/http-foundation"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/mailer"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/process"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/routing"
+      versions: [ "6.x" ]
+    - dependency-name: "symfony/translation"
+      versions: [ "6.x" ]
 
 - package-ecosystem: composer
   directory: "/"
@@ -23,7 +38,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
     - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
     - "dependencies"
     - "stable27"
@@ -40,7 +55,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
     - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
     - "dependencies"
     - "stable26"
@@ -56,7 +71,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
     - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
     - "dependencies"
     - "stable25"


### PR DESCRIPTION
We don't update minors on stable branches unless there are security issues, in which case we will notice via other sources but dependabot PRs.

Also configuring symfony to stay on 5.4 LTS for now while we need PHP 8.0 support