### PR TITLE
ZipStreamer & TarStreamer: patch to fix premature stream termination

### DIFF
--- a/deepdiver/zipstreamer/src/ZipStreamer.php
+++ b/deepdiver/zipstreamer/src/ZipStreamer.php
@@ -356,7 +356,7 @@ class ZipStreamer {
       $compStream = DeflateStream::create($level);
     }
 
-    while (!feof($stream) && $data = fread($stream, self::STREAM_CHUNK_SIZE)) {
+    while (!feof($stream) && ($data = fread($stream, self::STREAM_CHUNK_SIZE)) !== false) {
       $dataLength->add(strlen($data));
       hash_update($hashCtx, $data);
       if (COMPR::DEFLATE === $compress) {

--- a/deepdiver1975/tarstreamer/src/TarStreamer.php
+++ b/deepdiver1975/tarstreamer/src/TarStreamer.php
@@ -101,7 +101,7 @@ class TarStreamer {
 		$this->initFileStreamTransfer($filePath, self::REGTYPE, $size, $options);
 
 		// send file blocks
-		while ($data = fread($stream, $this->blockSize)) {
+		while (!feof($stream) && ($data = fread($stream, $this->blockSize)) !== false) {
 			// send data
 			$this->streamFilePart($data);
 		}


### PR DESCRIPTION
Fixes: https://github.com/nextcloud/server/issues/42248.
Upstream issue: https://github.com/DeepDiver1975/PHPZipStreamer/issues/19 & https://github.com/owncloud/TarStreamer/issues/31.
Upstream PR: https://github.com/DeepDiver1975/PHPZipStreamer/pull/20 & https://github.com/owncloud/TarStreamer/pull/32.