### PR TITLE
Quote error with pragma_foreign_key_list() causes errors and upgrade failures.

### DIFF
--- a/doctrine/dbal/src/Schema/SqliteSchemaManager.php
+++ b/doctrine/dbal/src/Schema/SqliteSchemaManager.php
@@ -744,7 +744,7 @@ SQL;
                    p.*
               FROM sqlite_master t
               JOIN pragma_foreign_key_list(t.name) p
-                ON p."seq" != "-1"
+                ON p."seq" != -1
 SQL;
 
         $conditions = [


### PR DESCRIPTION
The pragma_foreign_key_list() function returns a table with the "seq" column being a number. Attempting to treat this column as anything else is an error and causes errors. Fix that error by removing quote marks.

Discussion: https://github.com/nextcloud/server/issues/44445