### PR TITLE
fix(ci): Bring back reactions on `/composer-update` command

### DIFF
--- a/.github/workflows/composer-auto.yml
+++ b/.github/workflows/composer-auto.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           repository: ${{ github.event.repository.full_name }}
           comment-id: ${{ github.event.comment.id }}
-          reaction-type: "+1"
+          reactions: "+1"
 
       - name: Init branch
         uses: xt0rted/pull-request-comment-branch@v2
@@ -82,4 +82,4 @@ jobs:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           repository: ${{ github.event.repository.full_name }}
           comment-id: ${{ github.event.comment.id }}
-          reaction-type: "-1"
+          reactions: "-1"


### PR DESCRIPTION
In v4 of the action the option changed from `reaction-type` to `reactions`