### PR TITLE
[stable29] chore: set version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"name": "nextcloud/3rdparty",
+	"version": "dev-stable29",
 	"description": "All 3rdparty components",
 	"license": "MIT",
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "820dd815309efd712d25cb1b00365861",
+    "content-hash": "cc85aa0d53fea4e633696ffc23e64459",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -178,6 +178,10 @@
                 "MIT"
             ],
             "description": "Convenience wrapper around ini_get()",
+            "support": {
+                "issues": "https://github.com/bantuXorg/php-ini-get-wrapper/issues",
+                "source": "https://github.com/bantuXorg/php-ini-get-wrapper/tree/v1.0.1"
+            },
             "time": "2014-09-15T13:12:35+00:00"
         },
         {
@@ -212,12 +216,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Assert\\": "lib/Assert"
-                },
                 "files": [
                     "lib/Assert/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1047,6 +1051,7 @@
                 "issues": "https://github.com/fgrosse/PHPASN1/issues",
                 "source": "https://github.com/fgrosse/PHPASN1/tree/v2.3.0"
             },
+            "abandoned": true,
             "time": "2021-04-24T19:01:55+00:00"
         },
         {
@@ -1092,6 +1097,7 @@
                 "issues": "https://github.com/fusonic/linq/issues",
                 "source": "https://github.com/fusonic/linq/tree/master"
             },
+            "abandoned": true,
             "time": "2015-02-26T22:49:17+00:00"
         },
         {
@@ -1721,12 +1727,12 @@
             "version": "v5.2.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "shasum": ""
             },
@@ -1781,8 +1787,8 @@
                 "schema"
             ],
             "support": {
-                "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/v5.2.13"
+                "issues": "https://github.com/jsonrainbow/json-schema/issues",
+                "source": "https://github.com/jsonrainbow/json-schema/tree/v5.2.13"
             },
             "time": "2023-09-26T02:20:38+00:00"
         },
@@ -2391,6 +2397,10 @@
                 "log",
                 "normalizer"
             ],
+            "support": {
+                "issues": "https://github.com/nextcloud/lognormalizer/issues",
+                "source": "https://github.com/nextcloud/lognormalizer/tree/v1.0.0"
+            },
             "time": "2020-12-02T09:34:47+00:00"
         },
         {
@@ -3723,12 +3733,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Ramsey\\Uuid\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3750,6 +3760,10 @@
                 {
                     "url": "https://github.com/ramsey",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
+                    "type": "tidelift"
                 }
             ],
             "time": "2020-08-18T17:17:46+00:00"
@@ -4454,6 +4468,10 @@
                 }
             ],
             "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "support": {
+                "issues": "https://github.com/stecman/symfony-console-completion/issues",
+                "source": "https://github.com/stecman/symfony-console-completion/tree/0.11.0"
+            },
             "time": "2019-11-24T17:03:06+00:00"
         },
         {
@@ -6341,13 +6359,6 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "deprecated/",
-                        "generated/"
-                    ]
-                },
                 "files": [
                     "deprecated/apc.php",
                     "deprecated/libevent.php",
@@ -6438,7 +6449,14 @@
                     "generated/yaz.php",
                     "generated/zip.php",
                     "generated/zlib.php"
-                ]
+                ],
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "deprecated/",
+                        "generated/"
+                    ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/composer/installed.php
+++ b/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'nextcloud/3rdparty',
-        'pretty_version' => 'dev-master',
-        'version' => 'dev-master',
-        'reference' => 'a912b6da034f385b17707ce8c41275b91a593683',
+        'pretty_version' => 'dev-stable29',
+        'version' => 'dev-stable29',
+        'reference' => NULL,
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
@@ -317,9 +317,9 @@
             'dev_requirement' => false,
         ),
         'nextcloud/3rdparty' => array(
-            'pretty_version' => 'dev-master',
-            'version' => 'dev-master',
-            'reference' => 'a912b6da034f385b17707ce8c41275b91a593683',
+            'pretty_version' => 'dev-stable29',
+            'version' => 'dev-stable29',
+            'reference' => NULL,
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),


### PR DESCRIPTION
When running dump-autoload, then composer tries to find a matching version number.

Sometimes the VCS detection does not work and the generated version number changes from the commit hash to the fallback and back to the generated version when someone else updates the package.

We are now using a version number in composer.json to avoid a version number ping-pong.