### PR TITLE
ci: Reduce dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
+  commit-message:
+    prefix: "ci"
+    include: "scope"
   schedule:
     interval: "monthly"
 
@@ -12,25 +15,13 @@ updates:
     day: saturday
     time: "03:00"
     timezone: Europe/Paris
-  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "build"
+    include: "scope"
+  versioning-strategy: "increase"
   labels:
     - "dependencies"
     - "main"
-  ignore:
-    - dependency-name: "symfony/console"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/event-dispatcher"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/http-foundation"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/mailer"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/process"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/routing"
-      versions: [ "6.x" ]
-    - dependency-name: "symfony/translation"
-      versions: [ "6.x" ]
 
 - package-ecosystem: composer
   directory: "/"
@@ -40,42 +31,13 @@ updates:
     day: saturday
     time: "03:00"
     timezone: Europe/Paris
-  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "build"
+    include: "scope"
+  versioning-strategy: "increase"
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
     - "dependencies"
     - "stable30"
-
-- package-ecosystem: composer
-  directory: "/"
-  target-branch: stable29
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "03:00"
-    timezone: Europe/Paris
-  open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  labels:
-    - "dependencies"
-    - "stable29"
-
-- package-ecosystem: composer
-  directory: "/"
-  target-branch: stable28
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "03:00"
-    timezone: Europe/Paris
-  open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  labels:
-    - "dependencies"
-    - "stable28"


### PR DESCRIPTION
- Security updates will be done manually
- Other patch updates are only done on demand