### PR TITLE
Fix PHP deprecation warning: Make $path parameter in lseek() explicit…

### DIFF
--- a/icewind/smb/src/Native/NativeState.php
+++ b/icewind/smb/src/Native/NativeState.php
@@ -343,7 +343,7 @@ class NativeState {
 	 *
 	 * @return false|int new file offset as measured from the start of the file on success.
 	 */
-	public function lseek($file, int $offset, int $whence = SEEK_SET, string $path = null) {
+	public function lseek($file, int $offset, int $whence = SEEK_SET, ?string $path = null) {
 		if (!$this->state) {
 			throw new ConnectionException("Not connected");
 		}


### PR DESCRIPTION


Fix for 

```
{"reqId":"VmdyXSdD9e3wRPFSU0IJ","level":3,"time":"2025-09-13T15:05:02+00:00","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":"Icewind\\SMB\\Native\\NativeState::lseek(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead at /var/www/nextcloud/3rdparty/icewind/smb/src/Native/NativeState.php#346","userAgent":"--","version":"32.0.0.10","data":{"app":"PHP"},"id":"68c5883211eaa"}
```