### PR TITLE
fix(dav): avoid TypeError on public DAV HEAD range

### DIFF
--- a/sabre/dav/lib/DAV/CorePlugin.php
+++ b/sabre/dav/lib/DAV/CorePlugin.php
@@ -80,7 +80,7 @@ class CorePlugin extends ServerPlugin
         }
 
         if ('HEAD' === $request->getHeader('X-Sabre-Original-Method')) {
-            $body = '';
+            $body = fopen('php://temp', 'r+');
         } else {
             $body = $node->get();
         }

--- a/sabre/dav/lib/DAV/CorePlugin.php
+++ b/sabre/dav/lib/DAV/CorePlugin.php
@@ -83,15 +83,15 @@ class CorePlugin extends ServerPlugin
             $body = '';
         } else {
             $body = $node->get();
-
-            // Converting string into stream, if needed.
-            if (is_string($body)) {
-                $stream = fopen('php://temp', 'r+');
-                fwrite($stream, $body);
-                rewind($stream);
-                $body = $stream;
-            }
         }
+        // Converting string into stream, if needed.
+        if (is_string($body)) {
+            $stream = fopen('php://temp', 'r+');
+            fwrite($stream, $body);
+            rewind($stream);
+            $body = $stream;
+        }
+    
 
         /*
          * TODO: getetag, getlastmodified, getsize should also be used using


### PR DESCRIPTION
## Summary
Fix TypeError in Sabre CorePlugin when handling public DAV HEAD range requests by converting string bodies to streams before range handling.

## Problem
Public share DAV `HEAD` + `Range` can hit `stream_get_meta_data()` with a string body, causing a TypeError and breaking byte‑range streaming (e.g. slow PDF load).
Related: https://github.com/nextcloud/server/issues/57219

## Fix
Convert string `$body` to `php://temp` stream regardless of request method.

## Testing
```
curl -I -H "Range: bytes=0-1023" http://localhost:8080/public.php/dav/files/<token>
```
Before: `500 Internal Server Error`  
After: `206 Partial Content` + `Content-Range`
